### PR TITLE
changes prop declaration autofocus, readonly => autoFocus, readOnly

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -84,7 +84,7 @@ function DefaultArrayItem(props) {
                       tabIndex="-1"
                       style={btnStyle}
                       disabled={
-                        props.disabled || props.readonly || !props.hasMoveUp
+                        props.disabled || props.readOnly || !props.hasMoveUp
                       }
                       onClick={props.onReorderClick(
                         props.index,
@@ -100,7 +100,7 @@ function DefaultArrayItem(props) {
                       tabIndex="-1"
                       style={btnStyle}
                       disabled={
-                        props.disabled || props.readonly || !props.hasMoveDown
+                        props.disabled || props.readOnly || !props.hasMoveDown
                       }
                       onClick={props.onReorderClick(
                         props.index,
@@ -115,7 +115,7 @@ function DefaultArrayItem(props) {
                       className="array-item-remove"
                       tabIndex="-1"
                       style={btnStyle}
-                      disabled={props.disabled || props.readonly}
+                      disabled={props.disabled || props.readOnly}
                       onClick={props.onDropIndexClick(props.index)}
                     />
                   )}
@@ -159,7 +159,7 @@ function DefaultFixedArrayFieldTemplate(props) {
           <div style={{ position: "relative", float: "right" }}>
             <AddButton
               onClick={props.onAddClick}
-              disabled={props.disabled || props.readonly}
+              disabled={props.disabled || props.readOnly}
             />
           </div>
         )}
@@ -204,7 +204,7 @@ function DefaultNormalArrayFieldTemplate(props) {
               <AddButton
                 key={uuid4()}
                 onClick={props.onAddClick}
-                disabled={props.disabled || props.readonly}
+                disabled={props.disabled || props.readOnly}
               />
             </div>
           )}
@@ -221,8 +221,8 @@ class ArrayField extends Component {
     idSchema: {},
     required: false,
     disabled: false,
-    readonly: false,
-    autofocus: false,
+    readOnly: false,
+    autoFocus: false,
   };
 
   get itemTitle() {
@@ -359,8 +359,8 @@ class ArrayField extends Component {
       name,
       required,
       disabled,
-      readonly,
-      autofocus,
+      readOnly,
+      autoFocus,
       registry = getDefaultRegistry(),
       formContext,
       onBlur,
@@ -391,7 +391,7 @@ class ArrayField extends Component {
           itemErrorSchema,
           itemData: item,
           itemUiSchema: uiSchema.items,
-          autofocus: autofocus && index === 0,
+          autoFocus: autoFocus && index === 0,
           onBlur,
           onFocus,
         });
@@ -402,7 +402,7 @@ class ArrayField extends Component {
       idSchema,
       uiSchema,
       onAddClick: this.onAddClick,
-      readonly,
+      readOnly,
       required,
       schema,
       title,
@@ -423,8 +423,8 @@ class ArrayField extends Component {
       uiSchema,
       formData,
       disabled,
-      readonly,
-      autofocus,
+      readOnly,
+      autoFocus,
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
@@ -449,9 +449,9 @@ class ArrayField extends Component {
         schema={schema}
         value={items}
         disabled={disabled}
-        readonly={readonly}
+        readOnly={readOnly}
         formContext={formContext}
-        autofocus={autofocus}
+        autoFocus={autoFocus}
       />
     );
   }
@@ -463,8 +463,8 @@ class ArrayField extends Component {
       idSchema,
       name,
       disabled,
-      readonly,
-      autofocus,
+      readOnly,
+      autoFocus,
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
@@ -486,9 +486,9 @@ class ArrayField extends Component {
         title={title}
         value={items}
         disabled={disabled}
-        readonly={readonly}
+        readOnly={readOnly}
         formContext={formContext}
-        autofocus={autofocus}
+        autoFocus={autoFocus}
       />
     );
   }
@@ -503,8 +503,8 @@ class ArrayField extends Component {
       name,
       required,
       disabled,
-      readonly,
-      autofocus,
+      readOnly,
+      autoFocus,
       registry = getDefaultRegistry(),
       onBlur,
       onFocus,
@@ -562,13 +562,13 @@ class ArrayField extends Component {
           itemUiSchema,
           itemIdSchema,
           itemErrorSchema,
-          autofocus: autofocus && index === 0,
+          autoFocus: autoFocus && index === 0,
           onBlur,
           onFocus,
         });
       }),
       onAddClick: this.onAddClick,
-      readonly,
+      readOnly,
       required,
       schema,
       uiSchema,
@@ -592,13 +592,13 @@ class ArrayField extends Component {
       itemUiSchema,
       itemIdSchema,
       itemErrorSchema,
-      autofocus,
+      autoFocus,
       onBlur,
       onFocus,
     } = props;
     const {
       disabled,
-      readonly,
+      readOnly,
       uiSchema,
       registry = getDefaultRegistry(),
     } = this.props;
@@ -631,8 +631,8 @@ class ArrayField extends Component {
           onFocus={onFocus}
           registry={this.props.registry}
           disabled={this.props.disabled}
-          readonly={this.props.readonly}
-          autofocus={autofocus}
+          readOnly={this.props.readOnly}
+          autoFocus={autoFocus}
         />
       ),
       className: "array-item",
@@ -644,7 +644,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly,
+      readOnly,
     };
   }
 }
@@ -689,8 +689,8 @@ if (process.env.NODE_ENV !== "production") {
     formData: PropTypes.array,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     registry: PropTypes.shape({
       widgets: PropTypes.objectOf(
         PropTypes.oneOfType([PropTypes.func, PropTypes.object])

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -18,8 +18,8 @@ function BooleanField(props) {
     registry = getDefaultRegistry(),
     required,
     disabled,
-    readonly,
-    autofocus,
+    readOnly,
+    autoFocus,
     onChange,
   } = props;
   const { title } = schema;
@@ -40,10 +40,10 @@ function BooleanField(props) {
       value={formData}
       required={required}
       disabled={disabled}
-      readonly={readonly}
+      readOnly={readOnly}
       registry={registry}
       formContext={formContext}
-      autofocus={autofocus}
+      autoFocus={autoFocus}
     />
   );
 }
@@ -57,8 +57,8 @@ if (process.env.NODE_ENV !== "production") {
     formData: PropTypes.bool,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     registry: PropTypes.shape({
       widgets: PropTypes.objectOf(
         PropTypes.oneOfType([PropTypes.func, PropTypes.object])
@@ -73,8 +73,8 @@ if (process.env.NODE_ENV !== "production") {
 BooleanField.defaultProps = {
   uiSchema: {},
   disabled: false,
-  readonly: false,
-  autofocus: false,
+  readOnly: false,
+  autoFocus: false,
 };
 
 export default BooleanField;

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -137,7 +137,7 @@ if (process.env.NODE_ENV !== "production") {
     rawDescription: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     hidden: PropTypes.bool,
     required: PropTypes.bool,
-    readonly: PropTypes.bool,
+    readOnly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
     formContext: PropTypes.object,
@@ -146,7 +146,7 @@ if (process.env.NODE_ENV !== "production") {
 
 DefaultTemplate.defaultProps = {
   hidden: false,
-  readonly: false,
+  readOnly: false,
   required: false,
   displayLabel: true,
 };
@@ -171,8 +171,8 @@ function SchemaFieldRender(props) {
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
   const { DescriptionField } = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
-  const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
-  const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
+  const readOnly = Boolean(props.readOnly || uiSchema["ui:readOnly"]);
+  const autoFocus = Boolean(props.autoFocus || uiSchema["ui:autoFocus"]);
 
   if (Object.keys(schema).length === 0) {
     // See #312: Ensure compatibility with old versions of React.
@@ -205,8 +205,8 @@ function SchemaFieldRender(props) {
       schema={schema}
       uiSchema={{ ...uiSchema, classNames: undefined }}
       disabled={disabled}
-      readonly={readonly}
-      autofocus={autofocus}
+      readOnly={readOnly}
+      autoFocus={autoFocus}
       errorSchema={fieldErrorSchema}
       formContext={formContext}
     />
@@ -251,7 +251,7 @@ function SchemaFieldRender(props) {
     hidden,
     required,
     disabled,
-    readonly,
+    readOnly,
     displayLabel,
     classNames,
     formContext,
@@ -283,8 +283,8 @@ SchemaField.defaultProps = {
   errorSchema: {},
   idSchema: {},
   disabled: false,
-  readonly: false,
-  autofocus: false,
+  readOnly: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -18,8 +18,8 @@ function StringField(props) {
     formData,
     required,
     disabled,
-    readonly,
-    autofocus,
+    readOnly,
+    autoFocus,
     onChange,
     onBlur,
     onFocus,
@@ -46,9 +46,9 @@ function StringField(props) {
       onFocus={onFocus}
       required={required}
       disabled={disabled}
-      readonly={readonly}
+      readOnly={readOnly}
       formContext={formContext}
-      autofocus={autofocus}
+      autoFocus={autoFocus}
       registry={registry}
       placeholder={placeholder}
     />
@@ -75,16 +75,16 @@ if (process.env.NODE_ENV !== "production") {
     formContext: PropTypes.object.isRequired,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
   };
 }
 
 StringField.defaultProps = {
   uiSchema: {},
   disabled: false,
-  readonly: false,
-  autofocus: false,
+  readOnly: false,
+  autoFocus: false,
 };
 
 export default StringField;

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -23,8 +23,8 @@ function DateElement(props) {
     select,
     rootId,
     disabled,
-    readonly,
-    autofocus,
+    readOnly,
+    autoFocus,
     registry,
     onBlur,
   } = props;
@@ -39,8 +39,8 @@ function DateElement(props) {
       placeholder={type}
       value={value}
       disabled={disabled}
-      readonly={readonly}
-      autofocus={autofocus}
+      readOnly={readOnly}
+      autoFocus={autoFocus}
       onChange={value => select(type, value)}
       onBlur={onBlur}
     />
@@ -51,8 +51,8 @@ class AltDateWidget extends Component {
   static defaultProps = {
     time: false,
     disabled: false,
-    readonly: false,
-    autofocus: false,
+    readOnly: false,
+    autoFocus: false,
   };
 
   constructor(props) {
@@ -82,8 +82,8 @@ class AltDateWidget extends Component {
 
   setNow = event => {
     event.preventDefault();
-    const { time, disabled, readonly, onChange } = this.props;
-    if (disabled || readonly) {
+    const { time, disabled, readOnly, onChange } = this.props;
+    if (disabled || readOnly) {
       return;
     }
     const nowDateObj = parseDateString(new Date().toJSON(), time);
@@ -92,8 +92,8 @@ class AltDateWidget extends Component {
 
   clear = event => {
     event.preventDefault();
-    const { time, disabled, readonly, onChange } = this.props;
-    if (disabled || readonly) {
+    const { time, disabled, readOnly, onChange } = this.props;
+    if (disabled || readOnly) {
       return;
     }
     this.setState(parseDateString("", time), () => onChange(undefined));
@@ -118,7 +118,7 @@ class AltDateWidget extends Component {
   }
 
   render() {
-    const { id, disabled, readonly, autofocus, registry, onBlur } = this.props;
+    const { id, disabled, readOnly, autoFocus, registry, onBlur } = this.props;
     return (
       <ul className="list-inline">
         {this.dateElementProps.map((elemProps, i) => (
@@ -128,10 +128,10 @@ class AltDateWidget extends Component {
               select={this.onChange}
               {...elemProps}
               disabled={disabled}
-              readonly={readonly}
+              readOnly={readOnly}
               registry={registry}
               onBlur={onBlur}
-              autofocus={autofocus && i === 0}
+              autoFocus={autoFocus && i === 0}
             />
           </li>
         ))}
@@ -160,8 +160,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.string,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     time: PropTypes.bool,

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -7,9 +7,9 @@ function BaseInput(props) {
   // exclude the "options" and "schema" ones here.
   const {
     value,
-    readonly,
+    readOnly,
     disabled,
-    autofocus,
+    autoFocus,
     onBlur,
     onFocus,
     options,
@@ -30,9 +30,9 @@ function BaseInput(props) {
 
   return (
     <Input
-      focus={autofocus}
+      focus={autoFocus}
       disabled={disabled}
-      readOnly={readonly}
+      readOnly={readOnly}
       value={value === null ? "" : value}
       {...inputProps}
       onChange={_onChange}
@@ -46,8 +46,8 @@ BaseInput.defaultProps = {
   type: "text",
   required: false,
   disabled: false,
-  readonly: false,
-  autofocus: false,
+  readOnly: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -57,8 +57,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.any,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -10,13 +10,13 @@ function CheckboxWidget(props) {
     value,
     required,
     disabled,
-    readonly,
+    readOnly,
     label,
-    autofocus,
+    autoFocus,
     onChange,
   } = props;
   return (
-    <div className={`checkbox ${disabled || readonly ? "disabled" : ""}`}>
+    <div className={`checkbox ${disabled || readOnly ? "disabled" : ""}`}>
       {schema.description && (
         <DescriptionField description={schema.description} />
       )}
@@ -24,8 +24,8 @@ function CheckboxWidget(props) {
         id={id}
         checked={typeof value === "undefined" ? false : value}
         required={required}
-        disabled={disabled || readonly}
-        autoFocus={autofocus}
+        disabled={disabled || readOnly}
+        autoFocus={autoFocus}
         onChange={(event, data) => onChange(data.checked)}
         label={label}
       />
@@ -34,7 +34,7 @@ function CheckboxWidget(props) {
 }
 
 CheckboxWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -44,8 +44,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.bool,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
   };
 }

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -14,21 +14,21 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const { id, disabled, options, value, autofocus, readonly, onChange } = props;
+  const { id, disabled, options, value, autoFocus, readOnly, onChange } = props;
   const { enumOptions, inline } = options;
   return (
     <div className="checkboxes" id={id}>
       {enumOptions.map((option, index) => {
         const checked = value.indexOf(option.value) !== -1;
-        const disabledCls = disabled || readonly ? "disabled" : "";
+        const disabledCls = disabled || readOnly ? "disabled" : "";
         const checkbox = (
           <span>
             <input
               type="checkbox"
               id={`${id}_${index}`}
               checked={checked}
-              disabled={disabled || readonly}
-              autoFocus={autofocus && index === 0}
+              disabled={disabled || readOnly}
+              autoFocus={autoFocus && index === 0}
               onChange={event => {
                 const all = enumOptions.map(({ value }) => value);
                 if (event.target.checked) {
@@ -56,7 +56,7 @@ function CheckboxesWidget(props) {
 }
 
 CheckboxesWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
   options: {
     inline: false,
   },
@@ -72,10 +72,10 @@ if (process.env.NODE_ENV !== "production") {
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
-    readonly: PropTypes.bool,
+    readOnly: PropTypes.bool,
     disabled: PropTypes.bool,
     multiple: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
   };
 }

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -9,7 +9,7 @@ function ColorWidget(props) {
   const {
     value,
     //disabled,
-    //autofocus,
+    //autoFocus,
     //onBlur,
     //onFocus,
     options,
@@ -145,8 +145,8 @@ ColorWidget.defaultProps = {
   type: "text",
   required: false,
   disabled: false,
-  readonly: false,
-  autofocus: false,
+  readOnly: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -156,8 +156,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.any,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -93,7 +93,7 @@ class FileWidget extends Component {
   };
 
   render() {
-    const { multiple, id, readonly, disabled, autofocus } = this.props;
+    const { multiple, id, readOnly, disabled, autoFocus } = this.props;
     const { filesInfo } = this.state;
     return (
       <div>
@@ -102,10 +102,10 @@ class FileWidget extends Component {
             ref={ref => (this.inputRef = ref)}
             id={id}
             type="file"
-            disabled={readonly || disabled}
+            disabled={readOnly || disabled}
             onChange={this.onChange}
             defaultValue=""
-            autoFocus={autofocus}
+            autoFocus={autoFocus}
             multiple={multiple}
           />
         </p>
@@ -116,7 +116,7 @@ class FileWidget extends Component {
 }
 
 FileWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -126,7 +126,7 @@ if (process.env.NODE_ENV !== "production") {
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
     ]),
-    autofocus: PropTypes.bool,
+    autoFocus: PropTypes.bool,
   };
 }
 

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -11,7 +11,7 @@ class RadioGroup extends Component {
       enumOptions.map((option, i) => {
         const checked = option.value === this.props.value;
         const disabledCls =
-          this.props.disabled || this.props.readonly ? "disabled" : "";
+          this.props.disabled || this.props.readOnly ? "disabled" : "";
         const radio = (
           <Checkbox
             radio
@@ -19,8 +19,8 @@ class RadioGroup extends Component {
             name={name}
             required={this.props.required}
             value={option.value}
-            disabled={this.props.disabled || this.props.readonly}
-            autoFocus={this.props.autofocus && i === 0}
+            disabled={this.props.disabled || this.props.readOnly}
+            autoFocus={this.props.autoFocus && i === 0}
             onChange={_ => this.props.onChange(option.value)}
             label={option.label}
           />
@@ -46,7 +46,7 @@ class RadioGroup extends Component {
         {enumOptions.map((option, i) => {
           const checked = option.value === this.props.value;
           const disabledCls =
-            this.props.disabled || this.props.readonly ? "disabled" : "";
+            this.props.disabled || this.props.readOnly ? "disabled" : "";
           const radio = (
             <span>
               <Checkbox
@@ -55,8 +55,8 @@ class RadioGroup extends Component {
                 name={name}
                 required={this.props.required}
                 value={option.value}
-                disabled={this.props.disabled || this.props.readonly}
-                autoFocus={this.props.autofocus && i === 0}
+                disabled={this.props.disabled || this.props.readOnly}
+                autoFocus={this.props.autoFocus && i === 0}
                 onChange={_ => this.props.onChange(option.value)}
                 label={option.label}
               />
@@ -90,7 +90,7 @@ function RadioWidget(props) {
 }
 
 RadioWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -104,8 +104,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.any,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
   };
 }

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -42,9 +42,9 @@ function SelectWidget(props) {
     value,
     required,
     disabled,
-    readonly,
+    readOnly,
     multiple,
-    autofocus,
+    autoFocus,
     onChange,
     onBlur,
     onFocus,
@@ -68,8 +68,8 @@ function SelectWidget(props) {
       defaultValue={value}
       disabled={disabled}
       required={required}
-      autofocus={autofocus}
-      readonly={readonly}
+      autoFocus={autoFocus}
+      readOnly={readOnly}
       onBlur={
         onBlur &&
         ((event, self) => {
@@ -97,7 +97,7 @@ function SelectWidget(props) {
 }
 
 SelectWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -107,12 +107,16 @@ if (process.env.NODE_ENV !== "production") {
     options: PropTypes.shape({
       enumOptions: PropTypes.array,
     }).isRequired,
-    value: PropTypes.any,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.array,
+    ]),
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
+    readOnly: PropTypes.bool,
     multiple: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -10,8 +10,8 @@ function TextareaWidget(props) {
     value,
     required,
     disabled,
-    readonly,
-    autofocus,
+    readOnly,
+    autoFocus,
     onChange,
     onBlur,
     onFocus,
@@ -28,8 +28,8 @@ function TextareaWidget(props) {
         placeholder={placeholder}
         required={required}
         disabled={disabled}
-        readOnly={readonly}
-        autoFocus={autofocus}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
         rows={options.rows}
         onBlur={onBlur && (event => onBlur(id, event.target.value))}
         onFocus={onFocus && (event => onFocus(id, event.target.value))}
@@ -40,7 +40,7 @@ function TextareaWidget(props) {
 }
 
 TextareaWidget.defaultProps = {
-  autofocus: false,
+  autoFocus: false,
   options: {},
 };
 
@@ -55,8 +55,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.string,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
-    readonly: PropTypes.bool,
-    autofocus: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,


### PR DESCRIPTION
### Reasons for making this change
We are getting lots of warnings in our project, this is an effort to start stamping them out.
This simple PR fixes the invalid props that were being passed to react.

Fixes warnings as pictured:
```warning.js:33 Warning: Invalid DOM property `readonly`. Did you mean `readOnly`?```

<img width="1646" alt="screen shot 2018-06-13 at 9 05 45 pm" src="https://user-images.githubusercontent.com/20725340/41347699-d3a1fd5e-6f4d-11e8-9ebf-14d5a2ed864b.png">
<img width="1653" alt="screen shot 2018-06-13 at 9 05 24 pm" src="https://user-images.githubusercontent.com/20725340/41347701-d3e2113c-6f4d-11e8-8154-f0891c7932f8.png">


If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
